### PR TITLE
[feat] Event 리스트 조회 API 구현 완료

### DIFF
--- a/hyundai/src/main/java/org/sopt/hyundai/common/dto/SuccessCode.java
+++ b/hyundai/src/main/java/org/sopt/hyundai/common/dto/SuccessCode.java
@@ -2,10 +2,12 @@ package org.sopt.hyundai.common.dto;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
 public enum SuccessCode {
+    GET_EVENT_LIST_SUCCESS(HttpStatus.OK.value(), "이벤트 리스트 조회에 성공했습니다.")
     ;
     private final int status;
     private final String message;

--- a/hyundai/src/main/java/org/sopt/hyundai/event/controller/EventController.java
+++ b/hyundai/src/main/java/org/sopt/hyundai/event/controller/EventController.java
@@ -1,6 +1,5 @@
 package org.sopt.hyundai.event.controller;
 
-import jakarta.websocket.server.PathParam;
 import lombok.RequiredArgsConstructor;
 import org.sopt.hyundai.common.dto.ApiResponse;
 import org.sopt.hyundai.common.dto.SuccessCode;
@@ -17,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class EventController {
     private final EventService eventService;
     @GetMapping
-    public ResponseEntity<ApiResponse> findAllEvent(
+    public ResponseEntity<ApiResponse> getAllEvents(
             @RequestParam(required = false) String content
     ){
         if (content == null)

--- a/hyundai/src/main/java/org/sopt/hyundai/event/controller/EventController.java
+++ b/hyundai/src/main/java/org/sopt/hyundai/event/controller/EventController.java
@@ -1,0 +1,27 @@
+package org.sopt.hyundai.event.controller;
+
+import jakarta.websocket.server.PathParam;
+import lombok.RequiredArgsConstructor;
+import org.sopt.hyundai.common.dto.ApiResponse;
+import org.sopt.hyundai.common.dto.SuccessCode;
+import org.sopt.hyundai.event.service.EventService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/events")
+public class EventController {
+    private final EventService eventService;
+    @GetMapping
+    public ResponseEntity<ApiResponse> findAllEvent(
+            @RequestParam(required = false) String content
+    ){
+        if (content == null)
+            content = "";
+        return ResponseEntity.ok(ApiResponse.of(SuccessCode.GET_EVENT_LIST_SUCCESS, eventService.findAllEvent(content)));
+    }
+}

--- a/hyundai/src/main/java/org/sopt/hyundai/event/domain/Event.java
+++ b/hyundai/src/main/java/org/sopt/hyundai/event/domain/Event.java
@@ -1,0 +1,22 @@
+package org.sopt.hyundai.event.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access= AccessLevel.PROTECTED)
+public class Event {
+    @Id
+    @GeneratedValue(strategy= GenerationType.IDENTITY)
+    private Long id;
+    private String name;
+    private String description;
+    private String period;
+    private String image;
+}

--- a/hyundai/src/main/java/org/sopt/hyundai/event/dto/EventDto.java
+++ b/hyundai/src/main/java/org/sopt/hyundai/event/dto/EventDto.java
@@ -1,0 +1,15 @@
+package org.sopt.hyundai.event.dto;
+
+import org.sopt.hyundai.event.domain.Event;
+
+public record EventDto(
+        Long id,
+        String image,
+        String name,
+        String description,
+        String period
+) {
+    public static EventDto of(Event event){
+        return new EventDto(event.getId(), event.getImage(), event.getName(), event.getDescription(), event.getPeriod());
+    }
+}

--- a/hyundai/src/main/java/org/sopt/hyundai/event/dto/EventListDto.java
+++ b/hyundai/src/main/java/org/sopt/hyundai/event/dto/EventListDto.java
@@ -1,0 +1,11 @@
+package org.sopt.hyundai.event.dto;
+
+import java.util.List;
+
+public record EventListDto(
+        List<EventDto> events
+) {
+    public static EventListDto of(List<EventDto> events){
+        return new EventListDto(events);
+    }
+}

--- a/hyundai/src/main/java/org/sopt/hyundai/event/repository/EventRepository.java
+++ b/hyundai/src/main/java/org/sopt/hyundai/event/repository/EventRepository.java
@@ -1,0 +1,13 @@
+package org.sopt.hyundai.event.repository;
+
+import org.sopt.hyundai.event.domain.Event;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface EventRepository extends JpaRepository<Event, Long> {
+    @Query("select e from Event e where e.description like concat('%', :content, '%') or e.name like concat('%', :content, '%')")
+    List<Event> findAllByContent(@Param("content") String content);
+}

--- a/hyundai/src/main/java/org/sopt/hyundai/event/service/EventService.java
+++ b/hyundai/src/main/java/org/sopt/hyundai/event/service/EventService.java
@@ -14,7 +14,10 @@ public class EventService {
     private final EventRepository eventRepository;
 
     public EventListDto findAllEvent(String content){
-        List<EventDto> events = eventRepository.findAllByContent(content).stream().map(EventDto::of).toList();
+        List<EventDto> events = eventRepository.findAllByContent(content).stream()
+                .map(
+                        EventDto::of
+                ).toList();
         return EventListDto.of(events);
     }
 }

--- a/hyundai/src/main/java/org/sopt/hyundai/event/service/EventService.java
+++ b/hyundai/src/main/java/org/sopt/hyundai/event/service/EventService.java
@@ -1,0 +1,20 @@
+package org.sopt.hyundai.event.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.hyundai.event.dto.EventDto;
+import org.sopt.hyundai.event.dto.EventListDto;
+import org.sopt.hyundai.event.repository.EventRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class EventService {
+    private final EventRepository eventRepository;
+
+    public EventListDto findAllEvent(String content){
+        List<EventDto> events = eventRepository.findAllByContent(content).stream().map(EventDto::of).toList();
+        return EventListDto.of(events);
+    }
+}


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #1 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
- 이벤트 전체 리스트를 반환하거나, 검색을 했을 때 해당하는 이벤트 리스트를 반환하는 api를 구현했습니다.
## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->
- 검색안했을 경우
<img width="1135" alt="image" src="https://github.com/NOW-SOPT-CDSP-WEB3/server/assets/103352114/67bcbe3a-a631-4570-89c9-9c2c2d915680">
- 검색 했을 경우
<img width="867" alt="image" src="https://github.com/NOW-SOPT-CDSP-WEB3/server/assets/103352114/bada358b-bfb7-4983-94dc-dbf5e6f796a9">

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢
<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
