### PR TITLE
[feat] 회원가입/로그인 API 구현 

### DIFF
--- a/hyundai/build.gradle
+++ b/hyundai/build.gradle
@@ -24,6 +24,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'org.postgresql:postgresql'
     annotationProcessor 'org.projectlombok:lombok'

--- a/hyundai/src/main/java/org/sopt/hyundai/common/dto/ErrorCode.java
+++ b/hyundai/src/main/java/org/sopt/hyundai/common/dto/ErrorCode.java
@@ -10,6 +10,7 @@ public enum ErrorCode {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "서버 내부 오류입니다."),
     NOT_FOUND_END_POINT(HttpStatus.NOT_FOUND.value(), "존재하지 않는 API 입니다."),
     DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST.value(), "이미 존재하는 이메일입니다."),
+    LOGIN_FAILED(HttpStatus.UNAUTHORIZED.value(), "로그인에 실패하였습니다. 잘못된 이메일 또는 비밀번호입니다.");
     ;
     private final int status;
     private final String message;

--- a/hyundai/src/main/java/org/sopt/hyundai/common/dto/ErrorCode.java
+++ b/hyundai/src/main/java/org/sopt/hyundai/common/dto/ErrorCode.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ErrorCode {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "서버 내부 오류입니다."),
-    NOT_FOUND_END_POINT(HttpStatus.NOT_FOUND.value(), "존재하지 않는 API입니다."),
+    NOT_FOUND_END_POINT(HttpStatus.NOT_FOUND.value(), "존재하지 않는 API 입니다."),
+    DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST.value(), "이미 존재하는 이메일입니다."),
     ;
     private final int status;
     private final String message;

--- a/hyundai/src/main/java/org/sopt/hyundai/common/dto/SuccessCode.java
+++ b/hyundai/src/main/java/org/sopt/hyundai/common/dto/SuccessCode.java
@@ -2,10 +2,12 @@ package org.sopt.hyundai.common.dto;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
 public enum SuccessCode {
+    MEMBER_CREATE_SUCCESS(200, "성공");
     ;
     private final int status;
     private final String message;

--- a/hyundai/src/main/java/org/sopt/hyundai/common/dto/SuccessCode.java
+++ b/hyundai/src/main/java/org/sopt/hyundai/common/dto/SuccessCode.java
@@ -6,7 +6,8 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum SuccessCode {
-    MEMBER_CREATE_SUCCESS(200, "성공");
+    MEMBER_CREATE_SUCCESS(201, "회원가입 성공"),
+    MEMBER_LOGIN_SUCCESS(200, "로그인 성공")
     ;
     private final int status;
     private final String message;

--- a/hyundai/src/main/java/org/sopt/hyundai/common/dto/SuccessCode.java
+++ b/hyundai/src/main/java/org/sopt/hyundai/common/dto/SuccessCode.java
@@ -2,7 +2,6 @@ package org.sopt.hyundai.common.dto;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor

--- a/hyundai/src/main/java/org/sopt/hyundai/member/controller/MemberController.java
+++ b/hyundai/src/main/java/org/sopt/hyundai/member/controller/MemberController.java
@@ -7,10 +7,13 @@ import org.sopt.hyundai.common.dto.SuccessCode;
 import org.sopt.hyundai.member.service.MemberService;
 import org.sopt.hyundai.member.service.dto.MemberCreateRequest;
 import org.sopt.hyundai.member.service.dto.MemberCreateResponse;
+import org.sopt.hyundai.member.service.dto.MemberLoginRequest;
+import org.sopt.hyundai.member.service.dto.MemberLoginResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -23,9 +26,17 @@ public class MemberController {
 
     @PostMapping("/sign-up")
     public ResponseEntity<ApiResponse> createMember(
-        @Valid @RequestBody MemberCreateRequest memberCreateRequest) {
+            @Valid @RequestBody MemberCreateRequest memberCreateRequest) {
         MemberCreateResponse response = memberService.createMember(memberCreateRequest);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.of(SuccessCode.MEMBER_CREATE_SUCCESS, response));
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse> loginMember(
+            @RequestHeader
+            @Valid @RequestBody MemberLoginRequest memberLoginRequest) {
+        MemberLoginResponse response = memberService.loginMember(memberLoginRequest);
+        return ResponseEntity.ok(ApiResponse.of(SuccessCode.MEMBER_LOGIN_SUCCESS, response));
     }
 }

--- a/hyundai/src/main/java/org/sopt/hyundai/member/controller/MemberController.java
+++ b/hyundai/src/main/java/org/sopt/hyundai/member/controller/MemberController.java
@@ -1,0 +1,30 @@
+package org.sopt.hyundai.member.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.hyundai.common.dto.ApiResponse;
+import org.sopt.hyundai.common.dto.SuccessCode;
+import org.sopt.hyundai.member.service.MemberService;
+import org.sopt.hyundai.member.service.dto.MemberCreateRequest;
+import org.sopt.hyundai.member.service.dto.MemberCreateResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @PostMapping("/sign-up")
+    public ResponseEntity<ApiResponse> createMember(
+            @RequestBody MemberCreateRequest memberCreateRequest) {
+        MemberCreateResponse response = memberService.createMember(memberCreateRequest);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.of(SuccessCode.MEMBER_CREATE_SUCCESS, response));
+    }
+}

--- a/hyundai/src/main/java/org/sopt/hyundai/member/controller/MemberController.java
+++ b/hyundai/src/main/java/org/sopt/hyundai/member/controller/MemberController.java
@@ -1,5 +1,6 @@
 package org.sopt.hyundai.member.controller;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.sopt.hyundai.common.dto.ApiResponse;
 import org.sopt.hyundai.common.dto.SuccessCode;
@@ -22,7 +23,7 @@ public class MemberController {
 
     @PostMapping("/sign-up")
     public ResponseEntity<ApiResponse> createMember(
-            @RequestBody MemberCreateRequest memberCreateRequest) {
+        @Valid @RequestBody MemberCreateRequest memberCreateRequest) {
         MemberCreateResponse response = memberService.createMember(memberCreateRequest);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.of(SuccessCode.MEMBER_CREATE_SUCCESS, response));

--- a/hyundai/src/main/java/org/sopt/hyundai/member/domain/Member.java
+++ b/hyundai/src/main/java/org/sopt/hyundai/member/domain/Member.java
@@ -1,0 +1,39 @@
+package org.sopt.hyundai.member.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access= AccessLevel.PROTECTED)
+public class Member {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    String email;
+
+    @Column(nullable = false)
+    String password;
+
+    public static Member create(String email, String password) {
+        return Member.builder()
+                .email(email)
+                .password(password)
+                .build();
+    }
+
+    @Builder
+    private Member(String email, String password) {
+        this.email = email;
+        this.password = password;
+    }
+}

--- a/hyundai/src/main/java/org/sopt/hyundai/member/repository/MemberRepository.java
+++ b/hyundai/src/main/java/org/sopt/hyundai/member/repository/MemberRepository.java
@@ -1,0 +1,7 @@
+package org.sopt.hyundai.member.repository;
+
+import org.sopt.hyundai.member.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/hyundai/src/main/java/org/sopt/hyundai/member/repository/MemberRepository.java
+++ b/hyundai/src/main/java/org/sopt/hyundai/member/repository/MemberRepository.java
@@ -3,6 +3,9 @@ package org.sopt.hyundai.member.repository;
 import org.sopt.hyundai.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByEmail(String email);
+    Optional<Member> findByEmail(String email);
 }

--- a/hyundai/src/main/java/org/sopt/hyundai/member/repository/MemberRepository.java
+++ b/hyundai/src/main/java/org/sopt/hyundai/member/repository/MemberRepository.java
@@ -4,4 +4,5 @@ import org.sopt.hyundai.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+    boolean existsByEmail(String email);
 }

--- a/hyundai/src/main/java/org/sopt/hyundai/member/service/MemberService.java
+++ b/hyundai/src/main/java/org/sopt/hyundai/member/service/MemberService.java
@@ -1,6 +1,8 @@
 package org.sopt.hyundai.member.service;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.hyundai.common.dto.ErrorCode;
+import org.sopt.hyundai.exception.BusinessException;
 import org.sopt.hyundai.member.domain.Member;
 import org.sopt.hyundai.member.repository.MemberRepository;
 import org.sopt.hyundai.member.service.dto.MemberCreateRequest;
@@ -14,6 +16,10 @@ public class MemberService {
     private final MemberRepository memberRepository;
 
     public MemberCreateResponse createMember(MemberCreateRequest memberCreateRequest) {
+        if (memberRepository.existsByEmail(memberCreateRequest.email())) { // 이메일 중복을 잡아줌
+            throw new BusinessException(ErrorCode.DUPLICATE_EMAIL);
+        }
+
         Member member = memberRepository.save(Member.create(memberCreateRequest.email(), memberCreateRequest.password()));
         return new MemberCreateResponse(member.getId(), member.getEmail());
     }

--- a/hyundai/src/main/java/org/sopt/hyundai/member/service/MemberService.java
+++ b/hyundai/src/main/java/org/sopt/hyundai/member/service/MemberService.java
@@ -7,6 +7,8 @@ import org.sopt.hyundai.member.domain.Member;
 import org.sopt.hyundai.member.repository.MemberRepository;
 import org.sopt.hyundai.member.service.dto.MemberCreateRequest;
 import org.sopt.hyundai.member.service.dto.MemberCreateResponse;
+import org.sopt.hyundai.member.service.dto.MemberLoginRequest;
+import org.sopt.hyundai.member.service.dto.MemberLoginResponse;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -22,5 +24,17 @@ public class MemberService {
 
         Member member = memberRepository.save(Member.create(memberCreateRequest.email(), memberCreateRequest.password()));
         return new MemberCreateResponse(member.getId(), member.getEmail());
+    }
+
+    public MemberLoginResponse loginMember(MemberLoginRequest memberLoginRequest) {
+        Member member = memberRepository.findByEmail(memberLoginRequest.email()).orElseThrow(
+                () -> new BusinessException(ErrorCode.LOGIN_FAILED)
+        );
+
+        if (!memberLoginRequest.password().equals(member.getPassword())) {
+            throw new BusinessException(ErrorCode.LOGIN_FAILED);
+        }
+
+        return new MemberLoginResponse(member.getId(), member.getEmail());
     }
 }

--- a/hyundai/src/main/java/org/sopt/hyundai/member/service/MemberService.java
+++ b/hyundai/src/main/java/org/sopt/hyundai/member/service/MemberService.java
@@ -1,0 +1,20 @@
+package org.sopt.hyundai.member.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.hyundai.member.domain.Member;
+import org.sopt.hyundai.member.repository.MemberRepository;
+import org.sopt.hyundai.member.service.dto.MemberCreateRequest;
+import org.sopt.hyundai.member.service.dto.MemberCreateResponse;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    public MemberCreateResponse createMember(MemberCreateRequest memberCreateRequest) {
+        Member member = memberRepository.save(Member.create(memberCreateRequest.email(), memberCreateRequest.password()));
+        return new MemberCreateResponse(member.getId(), member.getEmail());
+    }
+}

--- a/hyundai/src/main/java/org/sopt/hyundai/member/service/dto/MemberCreateRequest.java
+++ b/hyundai/src/main/java/org/sopt/hyundai/member/service/dto/MemberCreateRequest.java
@@ -1,0 +1,7 @@
+package org.sopt.hyundai.member.service.dto;
+
+public record MemberCreateRequest(
+        String email,
+        String password
+) {
+}

--- a/hyundai/src/main/java/org/sopt/hyundai/member/service/dto/MemberCreateRequest.java
+++ b/hyundai/src/main/java/org/sopt/hyundai/member/service/dto/MemberCreateRequest.java
@@ -1,7 +1,14 @@
 package org.sopt.hyundai.member.service.dto;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
 public record MemberCreateRequest(
+        @NotBlank
+        @Email // 이메일 형식인 지 잡아줌
         String email,
+
+        @NotBlank
         String password
 ) {
 }

--- a/hyundai/src/main/java/org/sopt/hyundai/member/service/dto/MemberCreateResponse.java
+++ b/hyundai/src/main/java/org/sopt/hyundai/member/service/dto/MemberCreateResponse.java
@@ -1,0 +1,7 @@
+package org.sopt.hyundai.member.service.dto;
+
+public record MemberCreateResponse(
+        Long userId,
+        String email
+) {
+}

--- a/hyundai/src/main/java/org/sopt/hyundai/member/service/dto/MemberLoginRequest.java
+++ b/hyundai/src/main/java/org/sopt/hyundai/member/service/dto/MemberLoginRequest.java
@@ -1,0 +1,14 @@
+package org.sopt.hyundai.member.service.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record MemberLoginRequest(
+        @NotBlank
+        @Email
+        String email,
+
+        @NotBlank
+        String password
+) {
+}

--- a/hyundai/src/main/java/org/sopt/hyundai/member/service/dto/MemberLoginResponse.java
+++ b/hyundai/src/main/java/org/sopt/hyundai/member/service/dto/MemberLoginResponse.java
@@ -1,0 +1,7 @@
+package org.sopt.hyundai.member.service.dto;
+
+public record MemberLoginResponse(
+        Long userId,
+        String email
+) {
+}

--- a/hyundai/src/main/resources/application.yml
+++ b/hyundai/src/main/resources/application.yml
@@ -2,3 +2,21 @@ spring:
   web:
     resources:
       add-mappings: false
+
+  datasource:
+    url: jdbc:postgresql://localhost:5432/mydatabase
+    username:
+    password:
+    driver-class-name: org.postgresql.Driver
+
+  jpa:
+    show-sql: true
+    hibernate:
+      ddl-auto: create
+      format_sql: true
+      show_sql: true
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+
+


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #5 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
- 회원가입 로직을 진행하는 API를 개발하였습니다.
- 로그인 로직을 진행하는 API를 개발하였습니다.

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->
- `@Email` 어노테이션의 경우 DB에 동일한 이메일이 있을 때 예외를 반환하는 줄 알고 있었습니다.
- 하지만 해당 어노테이션은 이메일 형식이 아닌 경우(ex. test.naver.com) 예외를 발생시키는 어노테이션 이었습니다.
- 따라서 repository에서 DB에 해당 이메일이 존재하는지를 true/false로 알려주는 메서드를 생성하여, 서비스 레이어에서 DB에 이미 존재하는 이메일이면 예외를 발생시키도록 구현하였습니다.

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->
### 회원가입 성공
<img width="839" alt="image" src="https://github.com/NOW-SOPT-CDSP-WEB3/server/assets/125895298/5580c991-1659-4449-9c54-ca8864dd2c62">

<br>

### 동일한 이메일로 회원가입 하는 경우
<img width="843" alt="image" src="https://github.com/NOW-SOPT-CDSP-WEB3/server/assets/125895298/91d2acf1-f8f9-41ab-96de-4608c25c5458">

<br>

### 이메일 형식이 아닌 경우
<img width="833" alt="image" src="https://github.com/NOW-SOPT-CDSP-WEB3/server/assets/125895298/aea0b00f-e737-4035-811e-1d4c8f2046c1">

### 로그인 성공
![image](https://github.com/NOW-SOPT-CDSP-WEB3/server/assets/125895298/ed775f73-9188-443a-9b78-b0711ed8675d)

### 잘못된 이메일인 경우
![image](https://github.com/NOW-SOPT-CDSP-WEB3/server/assets/125895298/53f13aa0-4be3-4e3c-9763-790e6c2af1fb)

### 잘못된 비밀번호인 경우
![image](https://github.com/NOW-SOPT-CDSP-WEB3/server/assets/125895298/d7e5b326-926d-421f-acab-bc8984640fa0)


## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
