### PR TITLE
[feat] 카드 전체 조회 API 구현

### DIFF
--- a/hyundai/src/main/java/org/sopt/hyundai/card/controller/CardController.java
+++ b/hyundai/src/main/java/org/sopt/hyundai/card/controller/CardController.java
@@ -1,0 +1,23 @@
+package org.sopt.hyundai.card.controller;
+
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.hyundai.card.service.CardService;
+import org.sopt.hyundai.common.dto.ApiResponse;
+import org.sopt.hyundai.common.dto.SuccessCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class CardController {
+    private final CardService cardService;
+
+    @GetMapping("/cards")
+    public ResponseEntity<ApiResponse> getAllCards() {
+        return ResponseEntity.ok(ApiResponse.of(SuccessCode.GET_CARD_LIST_SUCCESS, cardService.findAllCards()));
+    }
+}

--- a/hyundai/src/main/java/org/sopt/hyundai/card/domain/Card.java
+++ b/hyundai/src/main/java/org/sopt/hyundai/card/domain/Card.java
@@ -1,0 +1,66 @@
+package org.sopt.hyundai.card.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Card {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private CardCategory cardCategory;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private boolean invitation;
+
+    @Column(nullable = false)
+    private String description;
+
+    @Column(nullable = false)
+    private String image;
+
+    @Column(nullable = false)
+    private boolean hasEvent;
+
+    @Enumerated(EnumType.STRING)
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name = "card_tags", joinColumns = @JoinColumn(name = "card_id"))
+    @Column(name = "tag")
+    private List<CardTag> cardTags;
+
+    @Builder
+    public Card(String name, boolean invitation, String description, String image, boolean hasEvent, CardCategory cardCategory, List<CardTag> cardTags) {
+        this.name = name;
+        this.invitation = invitation;
+        this.description = description;
+        this.image = image;
+        this.hasEvent = hasEvent;
+        this.cardCategory = cardCategory;
+        this.cardTags = cardTags;
+    }
+
+    public static Card create(String name, boolean invitation, String description, String image, boolean hasEvent, CardCategory cardCategory, List<CardTag> cardTags) {
+        return Card.builder()
+                .name(name)
+                .invitation(invitation)
+                .description(description)
+                .image(image)
+                .hasEvent(hasEvent)
+                .cardCategory(cardCategory)
+                .cardTags(cardTags)
+                .build();
+    }
+}

--- a/hyundai/src/main/java/org/sopt/hyundai/card/domain/CardCategory.java
+++ b/hyundai/src/main/java/org/sopt/hyundai/card/domain/CardCategory.java
@@ -1,0 +1,10 @@
+package org.sopt.hyundai.card.domain;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum CardCategory {
+    HYUNDAI_ORIGINALS,
+    CHAMPION_BRANDS,
+    AFFILIATE,
+    MY_BUSINESS
+}

--- a/hyundai/src/main/java/org/sopt/hyundai/card/domain/CardTag.java
+++ b/hyundai/src/main/java/org/sopt/hyundai/card/domain/CardTag.java
@@ -1,0 +1,13 @@
+package org.sopt.hyundai.card.domain;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum CardTag {
+    ALL,
+    PREMIUM,
+    M,
+    X,
+    Z,
+    ZERO;
+}
+

--- a/hyundai/src/main/java/org/sopt/hyundai/card/repository/CardRepository.java
+++ b/hyundai/src/main/java/org/sopt/hyundai/card/repository/CardRepository.java
@@ -1,0 +1,10 @@
+package org.sopt.hyundai.card.repository;
+
+import org.sopt.hyundai.card.domain.Card;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CardRepository extends JpaRepository<Card, Long> {
+
+}

--- a/hyundai/src/main/java/org/sopt/hyundai/card/service/CardService.java
+++ b/hyundai/src/main/java/org/sopt/hyundai/card/service/CardService.java
@@ -1,0 +1,38 @@
+package org.sopt.hyundai.card.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.hyundai.card.domain.Card;
+import org.sopt.hyundai.card.domain.CardCategory;
+import org.sopt.hyundai.card.repository.CardRepository;
+import org.sopt.hyundai.card.service.dto.CardCategoryResponse;
+import org.sopt.hyundai.card.service.dto.CardResponse;
+import org.sopt.hyundai.card.service.dto.CardsListResponse;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class CardService {
+
+    private final CardRepository cardRepository;
+
+    public CardsListResponse findAllCards() {
+        List<Card> cards = cardRepository.findAll();
+        Map<CardCategory, List<Card>> groupedCards = cards.stream()
+                .collect(Collectors.groupingBy(Card::getCardCategory));
+
+        List<CardCategoryResponse> cardCategories = groupedCards.entrySet().stream()
+                .map(entry -> CardCategoryResponse.of(
+                        entry.getKey(),
+                        entry.getValue().stream()
+                                .map(CardResponse::from)
+                                .toList()
+                ))
+                .toList();
+
+        return CardsListResponse.from(cardCategories);
+    }
+}

--- a/hyundai/src/main/java/org/sopt/hyundai/card/service/dto/CardCategoryResponse.java
+++ b/hyundai/src/main/java/org/sopt/hyundai/card/service/dto/CardCategoryResponse.java
@@ -1,0 +1,14 @@
+package org.sopt.hyundai.card.service.dto;
+
+import org.sopt.hyundai.card.domain.CardCategory;
+
+import java.util.List;
+
+public record CardCategoryResponse(
+        CardCategory cardCategory,
+        List<CardResponse> card
+) {
+    public static CardCategoryResponse of(CardCategory category, List<CardResponse> card) {
+        return new CardCategoryResponse(category, card);
+    }
+}

--- a/hyundai/src/main/java/org/sopt/hyundai/card/service/dto/CardResponse.java
+++ b/hyundai/src/main/java/org/sopt/hyundai/card/service/dto/CardResponse.java
@@ -1,0 +1,29 @@
+package org.sopt.hyundai.card.service.dto;
+
+import org.sopt.hyundai.card.domain.Card;
+
+import java.util.List;
+
+public record CardResponse(
+        Long id,
+        String name,
+        boolean invitation,
+        String description,
+        String image,
+        boolean hasEvent,
+        List<String> cardTags
+) {
+    public static CardResponse from(Card card) {
+        return new CardResponse(
+                card.getId(),
+                card.getName(),
+                card.isInvitation(),
+                card.getDescription(),
+                card.getImage(),
+                card.isHasEvent(),
+                card.getCardTags().stream()
+                        .map(Enum::name)
+                        .toList()
+        );
+    }
+}

--- a/hyundai/src/main/java/org/sopt/hyundai/card/service/dto/CardsListResponse.java
+++ b/hyundai/src/main/java/org/sopt/hyundai/card/service/dto/CardsListResponse.java
@@ -1,0 +1,12 @@
+package org.sopt.hyundai.card.service.dto;
+
+
+import java.util.List;
+
+public record CardsListResponse(
+        List<CardCategoryResponse> cards
+) {
+    public static CardsListResponse from(List<CardCategoryResponse> cards) {
+        return new CardsListResponse(cards);
+    }
+}

--- a/hyundai/src/main/java/org/sopt/hyundai/common/dto/SuccessCode.java
+++ b/hyundai/src/main/java/org/sopt/hyundai/common/dto/SuccessCode.java
@@ -7,7 +7,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum SuccessCode {
     MEMBER_CREATE_SUCCESS(201, "회원가입 성공"),
-    MEMBER_LOGIN_SUCCESS(200, "로그인 성공")
+    MEMBER_LOGIN_SUCCESS(200, "로그인 성공"),
+    GET_CARD_LIST_SUCCESS(200, "카드 리스트 조회 성공")
     ;
     private final int status;
     private final String message;

--- a/hyundai/src/main/resources/application.yml
+++ b/hyundai/src/main/resources/application.yml
@@ -5,18 +5,16 @@ spring:
 
   datasource:
     url: jdbc:postgresql://localhost:5432/mydatabase
-    username:
-    password:
+    username: test
+    password: test
     driver-class-name: org.postgresql.Driver
 
   jpa:
     show-sql: true
+    open-in-view: false
     hibernate:
-      ddl-auto: create
-      format_sql: true
-      show_sql: true
+      ddl-auto: update
     properties:
       hibernate:
-        dialect: org.hibernate.dialect.PostgreSQLDialect
-
-
+        format_sql: true
+        show_sql: true


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #8 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
- 특정 카테고리나, 특정 태그와 관계없이 모든 카드를 조회하는 API를 구현했습니다.
- 처음 카드 navigation에 진입했을 때 모든 카드를 조회하는 API에 요청이 가게됩니다. 
    - 따라서 기본 태그는 첫 진입 시 모두 All 태그로 설정됩니다.

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->
### 카드 전체 조회
![image](https://github.com/NOW-SOPT-CDSP-WEB3/server/assets/125895298/95956097-5471-4daf-8f24-e85704f5bdc8)

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
