### PR TITLE
[feat] 북마크 API 구현

### DIFF
--- a/hyundai/src/main/java/org/sopt/hyundai/bookmark/controller/BookmarkController.java
+++ b/hyundai/src/main/java/org/sopt/hyundai/bookmark/controller/BookmarkController.java
@@ -1,0 +1,25 @@
+package org.sopt.hyundai.bookmark.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.hyundai.bookmark.service.BookmarkService;
+import org.sopt.hyundai.bookmark.service.dto.BookMarkCreateRequest;
+import org.sopt.hyundai.bookmark.service.dto.BookmarkStatusResponse;
+import org.sopt.hyundai.common.dto.ApiResponse;
+import org.sopt.hyundai.common.dto.SuccessCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class BookmarkController {
+
+    private final BookmarkService bookmarkService;
+
+    @PostMapping("/bookmarks")
+    public ResponseEntity<ApiResponse> addLike(@RequestBody BookMarkCreateRequest bookMarkCreateRequest) {
+        boolean isBookmarked = bookmarkService.addLike(bookMarkCreateRequest);
+        BookmarkStatusResponse response = new BookmarkStatusResponse(isBookmarked);
+        return ResponseEntity.ok(ApiResponse.of(SuccessCode.BOOKMARK_SUCCESS, response));
+    }
+}

--- a/hyundai/src/main/java/org/sopt/hyundai/bookmark/domain/Bookmark.java
+++ b/hyundai/src/main/java/org/sopt/hyundai/bookmark/domain/Bookmark.java
@@ -1,0 +1,39 @@
+package org.sopt.hyundai.bookmark.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.sopt.hyundai.card.domain.Card;
+import org.sopt.hyundai.member.domain.Member;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Bookmark {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)  // 매핑되는 열 이름 지정
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "card_id", nullable = false)  // 매핑되는 열 이름 지정
+    private Card card;
+
+    public static Bookmark create(Member member, Card card) {
+        return Bookmark.builder()
+                .member(member)
+                .card(card)
+                .build();
+    }
+
+    @Builder
+    public Bookmark(Member member, Card card) {
+        this.member = member;
+        this.card = card;
+    }
+}

--- a/hyundai/src/main/java/org/sopt/hyundai/bookmark/repository/BookmarkRepository.java
+++ b/hyundai/src/main/java/org/sopt/hyundai/bookmark/repository/BookmarkRepository.java
@@ -1,0 +1,15 @@
+package org.sopt.hyundai.bookmark.repository;
+
+import jakarta.transaction.Transactional;
+import org.sopt.hyundai.bookmark.domain.Bookmark;
+import org.sopt.hyundai.card.domain.Card;
+import org.sopt.hyundai.member.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
+
+    @Transactional
+    void deleteByMemberAndCard(Member member, Card card);
+
+    boolean existsByMemberAndCard(Member member, Card card);
+}

--- a/hyundai/src/main/java/org/sopt/hyundai/bookmark/service/BookmarkService.java
+++ b/hyundai/src/main/java/org/sopt/hyundai/bookmark/service/BookmarkService.java
@@ -1,0 +1,36 @@
+package org.sopt.hyundai.bookmark.service;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.sopt.hyundai.bookmark.domain.Bookmark;
+import org.sopt.hyundai.bookmark.repository.BookmarkRepository;
+import org.sopt.hyundai.bookmark.service.dto.BookMarkCreateRequest;
+import org.sopt.hyundai.card.domain.Card;
+import org.sopt.hyundai.card.service.CardService;
+import org.sopt.hyundai.member.domain.Member;
+import org.sopt.hyundai.member.service.MemberService;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BookmarkService {
+    private final MemberService memberService;
+    private final CardService cardService;
+    private final BookmarkRepository bookmarkRepository;
+
+    @Transactional
+    public boolean addLike(BookMarkCreateRequest bookMarkCreateRequest) {
+        Member member = memberService.findById(bookMarkCreateRequest.memberId());
+        Card card = cardService.findById(bookMarkCreateRequest.cardId());
+
+        // 이미 북마크를 한 경우 북마크를 해제하고, 아닌 경우 북마크를 추가.
+        if (bookmarkRepository.existsByMemberAndCard(member, card)) {
+            bookmarkRepository.deleteByMemberAndCard(member, card);
+            return false;
+        } else {
+            Bookmark bookmark = Bookmark.create(member, card);
+            bookmarkRepository.save(bookmark);
+            return true;
+        }
+    }
+}

--- a/hyundai/src/main/java/org/sopt/hyundai/bookmark/service/dto/BookMarkCreateRequest.java
+++ b/hyundai/src/main/java/org/sopt/hyundai/bookmark/service/dto/BookMarkCreateRequest.java
@@ -1,0 +1,7 @@
+package org.sopt.hyundai.bookmark.service.dto;
+
+public record BookMarkCreateRequest(
+        Long memberId,
+        Long cardId
+) {
+}

--- a/hyundai/src/main/java/org/sopt/hyundai/bookmark/service/dto/BookmarkStatusResponse.java
+++ b/hyundai/src/main/java/org/sopt/hyundai/bookmark/service/dto/BookmarkStatusResponse.java
@@ -1,0 +1,4 @@
+package org.sopt.hyundai.bookmark.service.dto;
+
+public record BookmarkStatusResponse(boolean bookmarkStatus) {
+}

--- a/hyundai/src/main/java/org/sopt/hyundai/card/controller/CardController.java
+++ b/hyundai/src/main/java/org/sopt/hyundai/card/controller/CardController.java
@@ -1,14 +1,18 @@
 package org.sopt.hyundai.card.controller;
 
-
 import lombok.RequiredArgsConstructor;
+import org.sopt.hyundai.card.domain.CardCategory;
+import org.sopt.hyundai.card.domain.CardTag;
 import org.sopt.hyundai.card.service.CardService;
 import org.sopt.hyundai.common.dto.ApiResponse;
 import org.sopt.hyundai.common.dto.SuccessCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -18,6 +22,13 @@ public class CardController {
 
     @GetMapping("/cards")
     public ResponseEntity<ApiResponse> getAllCards() {
-        return ResponseEntity.ok(ApiResponse.of(SuccessCode.GET_CARD_LIST_SUCCESS, cardService.findAllCards()));
+        return ResponseEntity.ok(ApiResponse.of(SuccessCode.GET_ALL_CARD_LIST_SUCCESS, cardService.findAllCards()));
+    }
+
+    @GetMapping("/cards/filter")
+    public ResponseEntity<ApiResponse> getCardsByCategoryAndTags(
+            @RequestParam("category") CardCategory category,
+            @RequestParam("tags") List<CardTag> tags) {
+        return ResponseEntity.ok(ApiResponse.of(SuccessCode.GET_CARD_LIST_SUCCESS, cardService.findByCategoryAndTags(category, tags)));
     }
 }

--- a/hyundai/src/main/java/org/sopt/hyundai/card/domain/CardCategory.java
+++ b/hyundai/src/main/java/org/sopt/hyundai/card/domain/CardCategory.java
@@ -1,7 +1,5 @@
 package org.sopt.hyundai.card.domain;
 
-import com.fasterxml.jackson.annotation.JsonValue;
-
 public enum CardCategory {
     HYUNDAI_ORIGINALS,
     CHAMPION_BRANDS,

--- a/hyundai/src/main/java/org/sopt/hyundai/card/domain/CardTag.java
+++ b/hyundai/src/main/java/org/sopt/hyundai/card/domain/CardTag.java
@@ -10,4 +10,3 @@ public enum CardTag {
     Z,
     ZERO;
 }
-

--- a/hyundai/src/main/java/org/sopt/hyundai/card/repository/CardRepository.java
+++ b/hyundai/src/main/java/org/sopt/hyundai/card/repository/CardRepository.java
@@ -1,10 +1,12 @@
 package org.sopt.hyundai.card.repository;
 
 import org.sopt.hyundai.card.domain.Card;
+import org.sopt.hyundai.card.domain.CardCategory;
+import org.sopt.hyundai.card.domain.CardTag;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
+import java.util.List;
 
 public interface CardRepository extends JpaRepository<Card, Long> {
-
+    List<Card> findAllByCardCategoryAndCardTagsIn(CardCategory cardCategory, List<CardTag> cardTags);
 }

--- a/hyundai/src/main/java/org/sopt/hyundai/card/service/CardService.java
+++ b/hyundai/src/main/java/org/sopt/hyundai/card/service/CardService.java
@@ -3,6 +3,7 @@ package org.sopt.hyundai.card.service;
 import lombok.RequiredArgsConstructor;
 import org.sopt.hyundai.card.domain.Card;
 import org.sopt.hyundai.card.domain.CardCategory;
+import org.sopt.hyundai.card.domain.CardTag;
 import org.sopt.hyundai.card.repository.CardRepository;
 import org.sopt.hyundai.card.service.dto.CardCategoryResponse;
 import org.sopt.hyundai.card.service.dto.CardResponse;
@@ -36,6 +37,15 @@ public class CardService {
                 .toList();
 
         return CardsListResponse.from(cardCategories);
+    }
+
+    public CardsListResponse findByCategoryAndTags(CardCategory category, List<CardTag> tags) {
+        List<Card> cards = cardRepository.findAllByCardCategoryAndCardTagsIn(category, tags);
+        List<CardResponse> cardResponses = cards.stream()
+                .map(CardResponse::from)
+                .toList();
+
+        return CardsListResponse.from(List.of(CardCategoryResponse.of(category, cardResponses)));
     }
 
     public Card findById(long cardId) {

--- a/hyundai/src/main/java/org/sopt/hyundai/card/service/CardService.java
+++ b/hyundai/src/main/java/org/sopt/hyundai/card/service/CardService.java
@@ -7,6 +7,8 @@ import org.sopt.hyundai.card.repository.CardRepository;
 import org.sopt.hyundai.card.service.dto.CardCategoryResponse;
 import org.sopt.hyundai.card.service.dto.CardResponse;
 import org.sopt.hyundai.card.service.dto.CardsListResponse;
+import org.sopt.hyundai.common.dto.ErrorCode;
+import org.sopt.hyundai.exception.BusinessException;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -34,5 +36,11 @@ public class CardService {
                 .toList();
 
         return CardsListResponse.from(cardCategories);
+    }
+
+    public Card findById(long cardId) {
+        return cardRepository.findById(cardId).orElseThrow(
+                () -> new BusinessException(ErrorCode.CARD_NOT_FOUND_BY_ID_EXCEPTION)
+        );
     }
 }

--- a/hyundai/src/main/java/org/sopt/hyundai/common/dto/ErrorCode.java
+++ b/hyundai/src/main/java/org/sopt/hyundai/common/dto/ErrorCode.java
@@ -10,7 +10,9 @@ public enum ErrorCode {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "서버 내부 오류입니다."),
     NOT_FOUND_END_POINT(HttpStatus.NOT_FOUND.value(), "존재하지 않는 API 입니다."),
     DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST.value(), "이미 존재하는 이메일입니다."),
-    LOGIN_FAILED(HttpStatus.UNAUTHORIZED.value(), "로그인에 실패하였습니다. 잘못된 이메일 또는 비밀번호입니다.");
+    LOGIN_FAILED(HttpStatus.UNAUTHORIZED.value(), "로그인에 실패하였습니다. 잘못된 이메일 또는 비밀번호입니다."),
+    CARD_NOT_FOUND_BY_ID_EXCEPTION(HttpStatus.NOT_FOUND.value(), "존재하지 않는 카드 id 입니다"),
+    MEMBER_NOT_FOUND_BY_ID_EXCEPTION(HttpStatus.NOT_FOUND.value(), "존재하지 않는 멤버 id 입니다")
     ;
     private final int status;
     private final String message;

--- a/hyundai/src/main/java/org/sopt/hyundai/common/dto/SuccessCode.java
+++ b/hyundai/src/main/java/org/sopt/hyundai/common/dto/SuccessCode.java
@@ -8,7 +8,8 @@ import lombok.RequiredArgsConstructor;
 public enum SuccessCode {
     MEMBER_CREATE_SUCCESS(201, "회원가입 성공"),
     MEMBER_LOGIN_SUCCESS(200, "로그인 성공"),
-    GET_CARD_LIST_SUCCESS(200, "카드 리스트 조회 성공")
+    GET_CARD_LIST_SUCCESS(200, "카드 리스트 조회 성공"),
+    BOOKMARK_SUCCESS(200, "북마크 요청이 성공했습니다.")
     ;
     private final int status;
     private final String message;

--- a/hyundai/src/main/java/org/sopt/hyundai/common/dto/SuccessCode.java
+++ b/hyundai/src/main/java/org/sopt/hyundai/common/dto/SuccessCode.java
@@ -8,8 +8,9 @@ import lombok.RequiredArgsConstructor;
 public enum SuccessCode {
     MEMBER_CREATE_SUCCESS(201, "회원가입 성공"),
     MEMBER_LOGIN_SUCCESS(200, "로그인 성공"),
-    GET_CARD_LIST_SUCCESS(200, "카드 리스트 조회 성공"),
-    BOOKMARK_SUCCESS(200, "북마크 요청이 성공했습니다.")
+    GET_ALL_CARD_LIST_SUCCESS(200, "카드 리스트 조회 성공"),
+    BOOKMARK_SUCCESS(200, "북마크 요청이 성공했습니다."),
+    GET_CARD_LIST_SUCCESS(200, "카드 리스트 조회 성공")
     ;
     private final int status;
     private final String message;

--- a/hyundai/src/main/java/org/sopt/hyundai/member/service/MemberService.java
+++ b/hyundai/src/main/java/org/sopt/hyundai/member/service/MemberService.java
@@ -37,4 +37,9 @@ public class MemberService {
 
         return new MemberLoginResponse(member.getId(), member.getEmail());
     }
+
+    public Member findById(long memberId) {
+        return memberRepository.findById(memberId).orElseThrow(
+                () -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND_BY_ID_EXCEPTION));
+    }
 }


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #7 

## Work Description ✏️
- 카드에 북마크를 생성/취소 하는 API 를 구현했습니다.
    - 북마크를 누를 때마다 상태가 달라지기 때문에, 비멱등성인 점을 고려해 POST 메서드로 설계하였습니다.
- 처음에 누를 시 특정 카드에 북마크가 생기게 되며, 다시 누를 시 북마크가 취소가 됩니다.
    - 현재 어떤 상태(북마크 생성/취소)인지 나타내기 위해 북마크 상태(bookmarkStatus) 필드를 추가해 true/false로 상태를 나타내도록 구현했습니다. 

<!-- 작업 내용을 간단히 소개주세요 -->

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->
### 북마크 생성
![image](https://github.com/NOW-SOPT-CDSP-WEB3/server/assets/125895298/3bafd238-c180-4682-b7ad-a1f3dc027c82)

### 북마크 취소
![image](https://github.com/NOW-SOPT-CDSP-WEB3/server/assets/125895298/6062ae9b-91a4-4855-a35d-7520aa87fc4d)

### 존재하지 않는 memberId에 북마크 요청
![image](https://github.com/NOW-SOPT-CDSP-WEB3/server/assets/125895298/0ebc188c-7293-4304-8982-2874a2964439)

### 존재하지 않는 cardId에 북마크 요청
![image](https://github.com/NOW-SOPT-CDSP-WEB3/server/assets/125895298/cf3f1187-c5a8-4b52-a054-cbae347fb41d)

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
